### PR TITLE
Specified tab size in settings.json & disabled cache for vite eslint plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import eslintPlugin from 'vite-plugin-eslint'
 
 // vite.config.js
 export default defineConfig({
-  plugins: [eslintPlugin()],
+  plugins: [eslintPlugin({ cache: false })],
   server: {
     host: 'localhost',
     cors: '*',


### PR DESCRIPTION
Had some issues getting this template to work initially.

- Specified `editor.tabSize: 2` in settings.json to avoid issues for anyone using default VS Code settings.
- Disabled cache for [vite-plugin-eslint](https://github.com/gxmari007/vite-plugin-eslint) since it wasn't working properly. I would see linting errors after fixing & saving, emptying the file still wouldn't resolve it.
    - https://github.com/gxmari007/vite-plugin-eslint/issues/17
    - https://github.com/gxmari007/vite-plugin-eslint/issues/11